### PR TITLE
[#8] Add dot matrix visualization to dashboard map

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@turf/turf": "^7.3.4",
         "d3": "^7.9.0",
         "dexie": "^4.3.0",
         "leaflet": "^1.9.4",
@@ -1429,6 +1430,2062 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@turf/along": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.4.tgz",
+      "integrity": "sha512-PvIoXin0I1t3nRwJz7uqR6fsxDMqdGwJq90qGOeqkNwlZqlF+5o2wKHPwYwi0RXZhLvxRP5qlbNIvV8ADdbWxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.3.4.tgz",
+      "integrity": "sha512-235JAfbrNMjHQXQfd/p+fYnlfCHsQsKHda5Eeyc+/jIY0s5mKvhcxgFaOEnigA2q1n+PrVOExs3BViGTKnWhAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
+      "integrity": "sha512-UEQQFw2XwHpozSBAMEtZI3jDsAad4NnHL/poF7/S6zeDCjEBCkt3MYd6DSGH/cvgcOozxH/ky3/rIVSMZdx4vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.4.tgz",
+      "integrity": "sha512-D5ErVWtfQbEPh11yzI69uxqrcJmbPU/9Y59f1uTapgwAwQHQztDWgsYpnL3ns8r1GmPWLP8sGJLVTIk2TZSiYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.3.4.tgz",
+      "integrity": "sha512-HCn0q/WPVEE9Dztg7tCvClOPrrh9MoxNUk73byHvcZLBcvziN6F84f/ZbFcbQSh8hgOeVMs/keeqWMqsICcNLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.4.tgz",
+      "integrity": "sha512-XCDYQwCA41Bum3R1xX0Na1nR4ozoe/pCYy5bxqrzyMs87kPJUIfBrD5IWxjnZyLqFpfEpolMHJz5ed1uA2PanQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.4.tgz",
+      "integrity": "sha512-zvFjapyFaOrM8nBtAND7f4yb0BJV0jyj6cyoXyTYqLY+3Hn0eHgL0M8lwxDLbTom5KfqYDHDVDQC3+VSfypoEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.3.4.tgz",
+      "integrity": "sha512-+iDUeiBKByIs/6K5WW8pG6IDxrRLJHFLM80zSpzk2xBtgy3mq36NZwwt67Pu7EJAkc9GUXKIm9SkspoKue9aYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.4.tgz",
+      "integrity": "sha512-X/O+u/OsoJ99mujhlqviuB7HX0tdJ5931TBjNSseps43XtROVuB5PwBDgwKfu5lY1B4DSGAxbbxJ795RmPnguQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.3.4.tgz",
+      "integrity": "sha512-SHuAzjqaAes6ELDZcN/FKZWCQZsqwYv3gMosoLRFWTwKyBQe8i29e4y6XnXakDr1uklVUeRRcdhZ5oKtX9ABPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.4.tgz",
+      "integrity": "sha512-AJMGbtC6HiXgHvq0RNlTfsDB58Qf9Js45MP/APbhGTH4AiLZ8VMDISywVFNd7qN6oppNlDd3xApVR28+ti8bNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.3.4.tgz",
+      "integrity": "sha512-v/U3SuGdkexfLTMhho6Vj0OjqPUeYdThxp8zggGJ1VHow27fvLLez0DjUR3AftHjjHM6bRzZoNsu2qUlEe5hjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-equal": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.4.tgz",
+      "integrity": "sha512-Dl4O27ygi2NqskGQuvSlDLJYlJ2SPkHb3A9T/v6eAudjlMiKdEY6bMxKUfU5y+Px1WiCZxd+9rXGXJgGC3WiQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.3.4.tgz",
+      "integrity": "sha512-AhWqe7D1o0wp3d3QQRSqgWDI8s1JfTFKFe9rU5mrSxYPGlmaQsJC07RCaYfFiGym9lACd1lxBJiPidCbLaPOfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.4.tgz",
+      "integrity": "sha512-sxi41NXkb5hrJgOvpm32hyBLhW8fem0vn2XxR4+jyRg1rM/v3ziF10/VqC9KDZuDNZkt9JjL9B0825Cf7AN6Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.4.tgz",
+      "integrity": "sha512-Q3dlswIuqffSiMfln7xa36YDnN1TWtERMF/155rzjglm4NTUG/6S+gNsb8s6qpLjc+hN6btCq1ZjxAWurPf8Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-overlap": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.3.4.tgz",
+      "integrity": "sha512-sTNMqsUkLPnSJEqc2IZ5ig3nHRoubyOH2HW1LILqOybCJI630FEM9UoYP1pZniF5nwTyCjQWnXA1FxusVILuFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
+      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-70gm5x6YQOZKcw0b/O4jjMwVWnFj+Zb6TXozLgZFDZShc8pgTQtZku7K+HKZ7Eya+7usHIB4IimZauomOMa+iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.3.4.tgz",
+      "integrity": "sha512-XOwhjc0oCWhnBUB+l4drpXcg7mkNXPX3SuSz/Xv7gvLH/yRrBwzVGllzK1AHlGU9BVkGVBJIZGYX7jgTM681NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.3.4.tgz",
+      "integrity": "sha512-P6M9BtRvzFF2N5g+1/DTIbYGpEbwQ2sv/Pw+uj11P3NYAA9VE8mvrxFYf+CowFdSfY6bY4ejhuqKhrTmAMv7wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-crosses": "7.3.4",
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/boolean-overlap": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.4.tgz",
+      "integrity": "sha512-eLgi803gz0KcYkyxnnqnz9Vd6tw2/0eAExe/Rq8sO0dqypaSiomSumxjqu89d/yo24Qz8gW7c0kJ6YihNbMYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.4.tgz",
+      "integrity": "sha512-MVOCBDuOl3KGDsh2stW12RmiFaFeSkVjeUbZ+ADUtIVnv+jlFsmjBpFtsEw8s9YQn5g0667QppOshm0FBHA57Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@turf/buffer/node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.4.tgz",
+      "integrity": "sha512-4SsLMDHWthXbyIHsczgFCo4fx+8tC8w2+B5HdEuY+P+cSOOL4T+6QQzd7WWjuN/Y3ndowFssUmwRrvXuwVRxQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.3.4.tgz",
+      "integrity": "sha512-6foVk5HLjlSPr48EI686Eis6/bYrJiHjKQlwY/7YlJc1uDitsIjPw2LjUCGIUZDEd6PdNUgg1+LgI7klXYvW3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.3.4.tgz",
+      "integrity": "sha512-Bz6rDr0plQOGSXgT3X3t941pYd44a5vIY8OEt4Y11H1BsgpmzFc6g7L5mr7FXW/uiYGxOewAfNcVUYUdJf9kMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.3.4.tgz",
+      "integrity": "sha512-mOSupDF5qxQTA/kOWYletHcBJQ3S2gVl/IRgrBH/YY9yiFq6UGRpZ0sNcIML4H06u/1DY/jqqG+d1nc/1yIA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/convex": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.4.tgz",
+      "integrity": "sha512-6c3kyTSKBrmiPMe75UkHw6MgedroZ6eR5usEvdlDhXgA3MudFPXIZkMFmMd1h9XeJ9xFfkmq+HPCdF0cOzvztA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.4.tgz",
+      "integrity": "sha512-6ccr5iT51/XONF+pbpkqoRxKX4ZVWLubXb1frGCnClv2suo1UIY9SIlINNctVDupXd2P9PpqZCbrXATrcrokPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.3.4.tgz",
+      "integrity": "sha512-S61aJXLvPN/uZHtjzmJbLv7xhi28Sq3PshCIZSvno4Mo45bvl79Vg4aZskrG05AaSSbipplqfH+MZrkW9Xboeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.4.tgz",
+      "integrity": "sha512-pwQ+RyQw986uu7IulY/18NRAebwZZScb084bvVqVkTrllwLSv4oVBqUxmUMiwtp+PNdiRGRFOvNyZqtRsiD+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.3.4.tgz",
+      "integrity": "sha512-+zoSyiF0LilXy4Tr0/lC7IgqbTMZZ2wwP3iSrqre58b61pUtdhCnBcjA2r8FkcW7z3GMbGf5XkIWhO+b+vDSsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.3.4.tgz",
+      "integrity": "sha512-RkuXf767Shk0AfY+fh0PASVw8YR4H8zYR7XQrCgWd/bCuh6CXs7rWZ6UTLu/PiA6y6WsIhyAQv4LhNH5kCzpbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "@types/geokdbush": "^1.1.5",
+        "geokdbush": "^2.0.1",
+        "kdbush": "^4.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.3.4.tgz",
+      "integrity": "sha512-89mlwhcb+vyZAKX0eBa3LQ8VyIKLayrzJpKGb90sEkIu0hDua9JCE+zlbaPoUAvAqflEiX+poFFuh7pngtsBMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.3.4.tgz",
+      "integrity": "sha512-fG28oDZK4HCXC/AhF0pmHKLtI9DWwdJr/ktuWolrqzA5b1G7eawrXwDu8B5I3sXhdWonNRMcuLbIuz+XQscHKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.3.4.tgz",
+      "integrity": "sha512-wNp9ar4FfpTfQXLZWXQ/jUBBoUFOwRN/mmlv5xrhoYFpP/F5SNy7GVDMZXaBfHdUUplfJUPF5hIKQlCUR8+k3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.3.4.tgz",
+      "integrity": "sha512-HZa1CV2pv4Xpcoe3t5S3ZW6j9jVbc27exzKwZWF7MlFxSz4BKRirWiME8Fku8nvQcGafpfLc+Lwpma+nGvg06w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/tin": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.3.4.tgz",
+      "integrity": "sha512-zeNv0fFdOoHuOQB7nl6OLb0DyjvzDvm0e3zlFkph50GF9pEKOmkCSmlniw681aWL2aRBdWZBnON3rRzOS+9C7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.4.tgz",
+      "integrity": "sha512-YxoUJwkKmTHiRFQxMQOP0tz8Vy+ga5EXl+C+F/WubjDLwT1AJu5y8CNIjLvWyjPWckj/vZG4u/1js5bx6MLADA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.4.tgz",
+      "integrity": "sha512-kIxizNQrYLO2rtqUIeed0tPycicrXoipy/g9d4mjv91kzBEbwpyojz9zi8U9G1ISBfCEgA7wsViQD0r+8qzxXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.3.4.tgz",
+      "integrity": "sha512-xjGY1gQ4icWhDgsW0YfU2KQtij1+ru34AfvtkVMQEgI86O9EwjW2r9Jq5DJY2PMKPbor3kz9yM/RTOiDP7f3Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/flatten": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.4.tgz",
+      "integrity": "sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.3.4.tgz",
+      "integrity": "sha512-dVMNEmIluKgn7iQTmzJJOe0UASRNmmSdFX1boAev5MISaW3AvPiURCCOV+lTIeoaQbWRpEAESbAp6JIimXFr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.4.tgz",
+      "integrity": "sha512-SMgbERZl12j7H8YaIofmnf0NwAvdF5Wly4tjI/eUhj/sFOKrKXOS1lvCSBJ6uSV9tFijl3ecGOVOlTpURdZ30g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.3.4.tgz",
+      "integrity": "sha512-anXSjYMXGAyXT7rpO74VyRI0q/rPAbKE/MYvou+QvG0U/Oa7el0yF4JNNi9wKEAxXg/10aWm9kHp8s2caeLg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.4.tgz",
+      "integrity": "sha512-7QWhp3f8jhrWjvArhJ74hXBFHMaiJr/2Y1PzHCWue2/pC5MbbTV0o7peehwrrrJC/1uD6CVb3hlcb77IxtMQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.3.4.tgz",
+      "integrity": "sha512-Yt3HCh/qeNaXS4LYhXczFhBfTeaKlTBoxEw1OICb9RT3SiGU0XCxuK7H0W26OLo7XxB0qP7GPs2L3FZbiri6wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.3.4.tgz",
+      "integrity": "sha512-HME+kVMTyvcsYVY6dC6DTvuzq8vvDpw+C7PviEqpuT3KcVlBCoGPAqlWRdyWYOb9MDciOqNxvvJF/okpb/GQcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.4.tgz",
+      "integrity": "sha512-aDG/5mMCgKduqBwZ3XpLOdlE2hizV3fM+5dHCWyrBepCQLeM/QRvvpBDCdQKDWKpoIBmrGGYDNiOofnf3QmGhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.3.4.tgz",
+      "integrity": "sha512-JvfzWFL9efP+xKtOnKzGvwEIXfaN0CLZoPPxNnWa/cVisLs9FVMlC9PWnuL3/3aqH5VhBHPddmU8ipzNE6KIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "arc": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
+      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.3.4.tgz",
+      "integrity": "sha512-TDCgBykFdsrP3IOOfToiiLpYkbUb3eEEhM9riIqWht0ubKUY61LN7qVs9bxZD83hG6XaDB6uY7SWkxK1zIEopQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.3.4.tgz",
+      "integrity": "sha512-lwYSMbHxsXYEWObv0tyBCjwTLXyfsTvOLn/NFhlsGrNCYEXn8I1VPtLGwuxbSdF3hVRgurn8qftkB1npHrNs6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/hex-grid": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@turf/triangle-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.4.tgz",
+      "integrity": "sha512-VsqMEMeRWWs2mjwI7sTlUgH1cEfugTGhQ0nF8ncHG7YKd9HUUTzIKpn9FJeoguPWIYITcy1ar4yJEOU/hteBVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
+      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.3.4.tgz",
+      "integrity": "sha512-SFYefwjQdQfF0MV0zfaSwNg9J1wD7mfPP8scGcScKGM3admbwS2A3V8rqPADBfYLD2eCPBDFnySxcl9SHbPung==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.3.4.tgz",
+      "integrity": "sha512-UFRIULkIgkZOmrhLxExWvguixbzfoCgVcXIqo2Cp68do4v+nwc3pTM7MTt4DBVFloIdX0Usrn4K44LQ/V05gxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.4.tgz",
+      "integrity": "sha512-LZTKELWxvXl0vc9ZxVgi0v07fO9+2FrZOam2B10fz/eGjy3oKNazU5gjggbnc499wEIcJS4hN+VyjQZrmsJAdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.4.tgz",
+      "integrity": "sha512-Dg1GnQ/B2go5NIWXt91N4L7XTjIgIWCftBSYIXkrpIM7QGjItzglek0Z5caytvb8ZRWXzZOGs8//+Q5we91WuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.4.tgz",
+      "integrity": "sha512-nqZ+JKjDVIrvREFHgtJIP9Ps4WbWw3eStqdIzAPolrzoXyAZnpIKquyfRTxpJFYUUjDmf+uQ/SFWsPP4SOWAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.3.4.tgz",
+      "integrity": "sha512-xWEHR99EpUO5ZPEZhMfa0QvnFZC0W+QLxB1GcJcSeJAQ5ZMXUXY8doKF1Nztk0eppawMprEEO3nQWLvQoR4z2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/length": "7.3.4",
+        "@turf/line-slice-along": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.4.tgz",
+      "integrity": "sha512-XygbTvHa6A+v6l2ZKYtS8AAWxwmrPxKxfBbdH75uED1JvdytSLWYTKGlcU3soxd9sYb4x/g9sDvRIVyU6Lucrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.3.4.tgz",
+      "integrity": "sha512-CSrg3njde9Tx+C0oL+BHUpZYpgD+PEmzp0ldDNis5ZQiTe5tUrwiIyG7A/QXf9eDnGhtV1WhCAycX0Wjged4pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.4.tgz",
+      "integrity": "sha512-3GBECiwNAQ2MmSwiqAHMweIl+EiePK0Jx4fXxF1KFE+NGCDv/MbGcEYfAbmsTg8mg6oRI9D8fJZzrT44DHpHXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.4.tgz",
+      "integrity": "sha512-UeISzf/JHoWEY5yeoyvKwA5epWcvJMCpCwbIMolvfTC5pp+IVozjHPVCRvRWuzmbmAvetcW0unL5bjqi0ADmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.3.4.tgz",
+      "integrity": "sha512-6Vt4Eptdr2C5T+jtpbo8D4v8b6X7KqYonPPyMB6huv+Kcg3nz4JRI9OQCDCaon9rWvU3ffWwjsjcbJCQS9o0sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.3.4.tgz",
+      "integrity": "sha512-RT5HydNy8+m9Y3u39USeYZauG2EyMqCYoLnTpWcAxbZGdq9WjIwdzAwYir3d8eJkOzjlR6Khz071VM4Ufqs0Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.4.tgz",
+      "integrity": "sha512-l1zmCSUnGsiN4gf22Aw91a2VnYs5DZS67FdkYqKgr+wPEAL/gpQgIBBWSTmhwY8zb3NEqty+f/gMEe8EJAWYng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.3.4.tgz",
+      "integrity": "sha512-vRnDHjzwOroC74/fsJEU+dUeGhiR/B2bG0/HeEWRBplAjmwVPptRBmDGtXKTz8sbA6or17/XtOITp3zTU0lBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.3.4.tgz",
+      "integrity": "sha512-FJIlSk8m0AiqzNoLSMdYuhDRif6aeOYVdW/WxjEjpUoMalwy2w5MMlZqJB9zxt/xSrMq6lvTWJgZfZfGL2s4ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.4.tgz",
+      "integrity": "sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.4.tgz",
+      "integrity": "sha512-/XAeGvsz8l5HaqcP7TUlexzGfibqXozQgBZ8rH7az6op2Dfm3pL/Z7bKLHoVavM0ccBg0Pt7g6j9NM54kZWdKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.3.4.tgz",
+      "integrity": "sha512-SNb16szwEG0OiyNn3z9zvSnk3M3tfwvvN8i//9UIC32APEApI+MRXCl93H/qZkKMhhh/cHA0pF0pjYZwl5z8Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance-weight": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.3.4.tgz",
+      "integrity": "sha512-8EZlDy5poU0t7BDy8KTzOmfiGsAs2kWuB3/kgI4sMdbThKVk2P4hHKuToCSGvqAzwSy3B2qKYM1N6JeVWytu+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.4.tgz",
+      "integrity": "sha512-WfI09f2bX0nKx/jkO7zCt3tUrJulyAlUYQtZHP7lWYMCOmZ6Pq26D6lKWjpfs2it0OHbhlx1XF/UupEUaz830w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.3.4.tgz",
+      "integrity": "sha512-Nzp3ojQt0gDACNYG+oNWymRXAUCey0LzdiSezYtRwdA0/+FQCtuxP8Lbc8FftV10JL8D78/CRlmt7omaXLLXCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.3.4.tgz",
+      "integrity": "sha512-KAhMAnddbuWIEZuk2bK//g+xTeKn8aV9N2AaE27x6JMJyV/wqvatIuVVqEIXI3SkAFbhiVBpVuarvPYhrJ+fhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.3.4.tgz",
+      "integrity": "sha512-9CL3OJ4dEt266+fxYlOQeRFqAY3XtsAuak2Gpk+K8k+Y3yGv8pvyn3QaAQ6P2npbiKt0zfG8Md/+HBAPOMPQ0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-within": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.4.tgz",
+      "integrity": "sha512-tQfIxsJUxZqyO7OeJC25y3DqN9i4fmrAt4TBrPvZcIIwymgN7aMrElJKlg/dfi7JDihKp3h/CkWMjtMQA14Vwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.4.tgz",
+      "integrity": "sha512-IdPAxlAQZj7FCZg+ObyVHlNdqwLL/oxYoQjpxMNJ511gNxokCtEv0aeRZQjYOYIxr9Ss97v3yo3ILJaF9V2kPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-polygon-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.3.4.tgz",
+      "integrity": "sha512-VxbkgHyzCkYWSxirqSUqw+lzbYmTf2qFhVZ/T5dprhwyXWcgalpupvgRzmZmjKkgsoJ017vrvCNKZRaCCn+Z7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.3.4.tgz",
+      "integrity": "sha512-HfT83Iw99zywDfCp+nJwS+JDzH+GdNug0sut9WDjGEznHKoZyAcOk+hGKL/ja8TeCLx9VsZHOiVCQFm+NTgvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.3.4.tgz",
+      "integrity": "sha512-AnpaGgNYVvP/dfz10id3AotDrUh9O+4unXCk3es1ff51VrpUhVgH3H+zyTSbVL4zAXN/ejPb8UnKCxDvNOQs4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.3.4.tgz",
+      "integrity": "sha512-D1IFocXJYF8PUMZ+BmnOstyRrzklqC86FgakYVk9O61F9Ki8LhMGaRfF+6reKMD473KvHvEf1M2EgmGt+OHDRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-within": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.4.tgz",
+      "integrity": "sha512-xhmOZ5rHZAKLUDLeYKWMsX84ip8CCGOcGLBHtPPYOjdIDHddMV6Sxt5kVgkmlZpK6NEWEmOD6lYR4obxHcHlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.3.4.tgz",
+      "integrity": "sha512-kmj05rkJ4tE8LvbQ4GVsL5GOrRiX/F5W4RIdxo8gPGTw1Y5oLG/1vFk6Hg6x63L1WcdNtF0sq6AdEI0G9BXWXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/envelope": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.4.tgz",
+      "integrity": "sha512-p91zOaLmzoBHzU/2H6Ot1tOhTmAom85n1P7I4Oo0V9xU8hmJXWfNnomLFf/6rnkKDIFZkncLQIBz4iIecZ61sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.3.4.tgz",
+      "integrity": "sha512-Yxqq8wgrDiXIX+s0uOZ2exmYfRwTIcUX8J7j4P+sbyLVbyN8W3AjN2s5ZX21P0aFf3v24FBd2fNWlm5VmMUAdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/random": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.3.4.tgz",
+      "integrity": "sha512-CXMS5XDoI5x0zc1aCYbn3t603k8hjaFHNsSOvGBW20z68cwP0UwMQQr0KLqFPqI4J1O7dMX+urn8IHH27RXFYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.3.4.tgz",
+      "integrity": "sha512-qM7vujJ4wndB4MKZlEcnUSawgvs5wXpSEFf4f+LWRIfmGhtv6serzDqFzWcmy8kF8hg5J465PMktRmAFWq/a+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-intersects": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.4.tgz",
+      "integrity": "sha512-4BZ8MHMujl4NAT7XnIs7JoOuDhpR96oDTB0RtqTeIP4onioIedVnw1ZA3Uq08sILGpR0qKLuDsvdz4x9jtbptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.4.tgz",
+      "integrity": "sha512-tvX1toSo80q0iL0cUMMXpSKsCCfOjRqDGCmOdR6B9shhk6xP1ZM2PLQDr+MFPBFeGyQuyY4CNFkV2+3DF49vYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.4.tgz",
+      "integrity": "sha512-6HikEb5nm2A18FQWk6vVLMQkc099I/7c69j47RYM27xQK8J8uBCNk1zLYyMPcZTh24xcNSbZ1iPHDsDOqw6wWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.4.tgz",
+      "integrity": "sha512-phwskeijdgYMsR3qDQmytfsg2iZcp3uWK7UFc76wKTEpxozbDGFI4enX5gXvZPpyI1iD7gsktGqHsO33AjnFDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.3.4.tgz",
+      "integrity": "sha512-XzAATg09c2XYAXkIBbg8lktSrU1tXNjJYXtbVwF6jLp1q2wTRpwb+mZpTEPAwzZwVF81uR5c0CsdQyr5UHINVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.4.tgz",
+      "integrity": "sha512-x2tNAXl21HRcF302ghU5ohE/vmmfDcXpQKgoWHyi7o5Q9kDRBwy7kbvr5YxbT3vwW/kAWUDYM7FoXNH42bXgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-arc": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.3.4.tgz",
+      "integrity": "sha512-xbK/oM+JRL+lJCHkAdZ3QPgoivT40J9WKJ0d1Ddt8LXTpzX2YeJVgcwOZaBPG9ncZUzHfHIWS1rUjc54clnZcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/clean-coords": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/transform-scale": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.3.4.tgz",
+      "integrity": "sha512-OoSwu3vI0H9P+GzLDaOJIL9v0V8ubeP8wQjM8GeMEZrq6U2uh9JWQnAU+jviT3ODcKF5H+88snpiMik585L0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.3.4.tgz",
+      "integrity": "sha512-vJ+NeiEaOVsb8YiUExtyIgvH+ZybthHszl2TASZn5q340ioKHPb2JeHGlbgrB2x8pEMh3MVhoqxAbXDuND/cnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.3.4.tgz",
+      "integrity": "sha512-MgjlVRklQYFfQm9yJNha9kXothLPliVdeycNdmn4lWLH3SOZe1rqJPB5Z9+dhmJELT3BJraDq3W5ik5taEpKyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/rectangle-grid": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.3.4.tgz",
+      "integrity": "sha512-+BaetOKN8zA2mQCVTcRWMcfidNR3JkjmYj0r5iGRncK0J+pdxIjX2q6sF6yBMOOxMoEMy393P7j07HdBIPbibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.4",
+        "@turf/ellipse": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/points-within-polygon": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.3.4.tgz",
+      "integrity": "sha512-ienLhLzBLeChtKhbJMmU3/vGg0hWzi6Wh/q0n39W4CmdNb+yAoGQhlYjcCbPOJT4IcdFlWE3OhbP9EmH/xPgfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.3.4.tgz",
+      "integrity": "sha512-NnDgVb5ZchJEhEpq1je2hktS5UhnHMfeeumxZQgnIoMeGILpJtcOL//b/1biBBUVSJ0ZZg5zxiHdQc1PgK2gxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.3.4.tgz",
+      "integrity": "sha512-tuegrGlbKPp6Dm8r5SuYDtQ2EVzdXVVxelqI1agnzj9N+l8oTBIKLRxRbBkLsizeVIDnlmVHCQB6cRc3v+u8JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.4.tgz",
+      "integrity": "sha512-pbUG6QLwyJvvitq4aAq4IQH79X8T0NmEPUGDUEEP69yW7t4+UZjDBAVbCKwpOc8gtsK0K5yvxlZ0e2CdtpNmEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.4.tgz",
+      "integrity": "sha512-7gUIFFHaU3Ewj3rCzIu5Yo7Zjfv4R2ypjh6UWiMJnDavb7RQ8fn0AKKcNMA/vF/yxuncp2l3zoa2gygv4AKM8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.4.tgz",
+      "integrity": "sha512-qbSIEueOR8mNB7p4EB88vHvUAyuSBM8zxP68UiiTNV3Gh+OZF2VXTFiu3EFYMTaD9sE6Lxmzvv3fjW8N2q82pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.3.4.tgz",
+      "integrity": "sha512-0bki10XwYvNcPzDcSs5kUh3niOogdVeFtawJEz5FdlyTAUohbNlC+Vb40K//OqEyTrGII+q1/dE4q+1J6ZCmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.4.tgz",
+      "integrity": "sha512-VPXdae9+RLLM19FMrJgt7QANBikm7DxPbfp/dXgzE4Ca7v+mJ4T1fYc7gCZDaqOrWMccHKbvv4iSuW7YZWdIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.3.4.tgz",
+      "integrity": "sha512-uMAKLYt2tWJj8xIepq4vExF1r8fzJviP/5l/elDHuRyauI2mASy/Gox6kSFlrN0t0p8AT4Cs8o//4GuJTXyC+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "7.3.4",
+        "@turf/angle": "7.3.4",
+        "@turf/area": "7.3.4",
+        "@turf/bbox": "7.3.4",
+        "@turf/bbox-clip": "7.3.4",
+        "@turf/bbox-polygon": "7.3.4",
+        "@turf/bearing": "7.3.4",
+        "@turf/bezier-spline": "7.3.4",
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/boolean-concave": "7.3.4",
+        "@turf/boolean-contains": "7.3.4",
+        "@turf/boolean-crosses": "7.3.4",
+        "@turf/boolean-disjoint": "7.3.4",
+        "@turf/boolean-equal": "7.3.4",
+        "@turf/boolean-intersects": "7.3.4",
+        "@turf/boolean-overlap": "7.3.4",
+        "@turf/boolean-parallel": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/boolean-touches": "7.3.4",
+        "@turf/boolean-valid": "7.3.4",
+        "@turf/boolean-within": "7.3.4",
+        "@turf/buffer": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/center-mean": "7.3.4",
+        "@turf/center-median": "7.3.4",
+        "@turf/center-of-mass": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/circle": "7.3.4",
+        "@turf/clean-coords": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/clusters": "7.3.4",
+        "@turf/clusters-dbscan": "7.3.4",
+        "@turf/clusters-kmeans": "7.3.4",
+        "@turf/collect": "7.3.4",
+        "@turf/combine": "7.3.4",
+        "@turf/concave": "7.3.4",
+        "@turf/convex": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/difference": "7.3.4",
+        "@turf/dissolve": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/distance-weight": "7.3.4",
+        "@turf/ellipse": "7.3.4",
+        "@turf/envelope": "7.3.4",
+        "@turf/explode": "7.3.4",
+        "@turf/flatten": "7.3.4",
+        "@turf/flip": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/great-circle": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/hex-grid": "7.3.4",
+        "@turf/interpolate": "7.3.4",
+        "@turf/intersect": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/isobands": "7.3.4",
+        "@turf/isolines": "7.3.4",
+        "@turf/kinks": "7.3.4",
+        "@turf/length": "7.3.4",
+        "@turf/line-arc": "7.3.4",
+        "@turf/line-chunk": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-offset": "7.3.4",
+        "@turf/line-overlap": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/line-slice": "7.3.4",
+        "@turf/line-slice-along": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@turf/line-to-polygon": "7.3.4",
+        "@turf/mask": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/midpoint": "7.3.4",
+        "@turf/moran-index": "7.3.4",
+        "@turf/nearest-neighbor-analysis": "7.3.4",
+        "@turf/nearest-point": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/nearest-point-to-line": "7.3.4",
+        "@turf/planepoint": "7.3.4",
+        "@turf/point-grid": "7.3.4",
+        "@turf/point-on-feature": "7.3.4",
+        "@turf/point-to-line-distance": "7.3.4",
+        "@turf/point-to-polygon-distance": "7.3.4",
+        "@turf/points-within-polygon": "7.3.4",
+        "@turf/polygon-smooth": "7.3.4",
+        "@turf/polygon-tangents": "7.3.4",
+        "@turf/polygon-to-line": "7.3.4",
+        "@turf/polygonize": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/quadrat-analysis": "7.3.4",
+        "@turf/random": "7.3.4",
+        "@turf/rectangle-grid": "7.3.4",
+        "@turf/rewind": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@turf/sample": "7.3.4",
+        "@turf/sector": "7.3.4",
+        "@turf/shortest-path": "7.3.4",
+        "@turf/simplify": "7.3.4",
+        "@turf/square": "7.3.4",
+        "@turf/square-grid": "7.3.4",
+        "@turf/standard-deviational-ellipse": "7.3.4",
+        "@turf/tag": "7.3.4",
+        "@turf/tesselate": "7.3.4",
+        "@turf/tin": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@turf/transform-scale": "7.3.4",
+        "@turf/transform-translate": "7.3.4",
+        "@turf/triangle-grid": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@turf/union": "7.3.4",
+        "@turf/unkink-polygon": "7.3.4",
+        "@turf/voronoi": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "@types/kdbush": "^3.0.5",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.4.tgz",
+      "integrity": "sha512-JJYyPMmGcrTa9sPv2ief2QU9Hb//cEAU1zgKu/OfoCMa9a8Imp5QVm9UTAkhGlc+4qm/N/X16iJ+cvVWaxPjkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.3.4.tgz",
+      "integrity": "sha512-dFIqTLAnLL5D3OANPJtRb5OvmOM81GlNCjwgjlLQy0xdpYgKwGdE+gNXjygDrPUUXNc22xnaj3EfAfC3Pq7W4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.3.4.tgz",
+      "integrity": "sha512-cwKSiDzDHRnA7yafQ1zOhWxRuMzp+fYFFzadCdByBAG1jAD7UlFwKhS1fjNPBNs67Fl5X3LL5ahCLW5gEdFgmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1537,6 +3594,12 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1544,11 +3607,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geokdbush": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/geokdbush/-/geokdbush-1.1.5.tgz",
+      "integrity": "sha512-jIsYnXY+RQ/YCyBqeEHxYN9mh+7PqKJUJUp84wLfZ7T2kqyVPNaXwZuvf1A2uQUkrvVqEbsG94ff8jH32AlLvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/kdbush": "^1"
+      }
+    },
+    "node_modules/@types/geokdbush/node_modules/@types/kdbush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-1.0.7.tgz",
+      "integrity": "sha512-QM5iB8m/0mnGOjUKshErIZQ0LseyTieRSYc3yaOpmrRM0xbWiOuJUWlduJx+TPNK7/VFMWphUGwx3nus7eT1Wg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/kdbush": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/kdbush/-/kdbush-3.0.5.tgz",
+      "integrity": "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1654,6 +3744,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/arc/-/arc-0.2.0.tgz",
+      "integrity": "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1676,6 +3774,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/brace-expansion": {
@@ -1815,6 +3922,24 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "license": "ISC",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/concaveman/node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2230,6 +4355,12 @@
         "d3-selection": "2 - 3"
       }
     },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
@@ -2291,6 +4422,12 @@
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.3.0.tgz",
       "integrity": "sha512-5EeoQpJvMKHe6zWt/FSIIuRa3CWlZeIl6zKXt+Lz7BU6RoRRLgX9dZEynRfXrkLcldKYCBiz7xekTEylnie1Ug==",
       "license": "Apache-2.0"
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -2568,7 +4705,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2677,6 +4813,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.2.tgz",
+      "integrity": "sha512-6XRNF4CsRHYmR9z5YuIk5f/aOototnDf0dgMqYGcS7y1l57ttt6MAIAxl3rXyas6lq1HEbTuLMh4PgvO+OV42w==",
+      "license": "MIT",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "license": "ISC"
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/geokdbush": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/geokdbush/-/geokdbush-2.0.1.tgz",
+      "integrity": "sha512-0M8so1Qx6+jJ1xpirpCNrgUsWAzIcQ3LrLmh0KJPBYI3gH7vy70nY5zEEjSp9Tn0nBt6Q2Fh922oL08lfib4Zg==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^2.0.3"
       }
     },
     "node_modules/glob-parent": {
@@ -2896,6 +5074,21 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3125,6 +5318,31 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -3172,6 +5390,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/react": {
@@ -3412,6 +5645,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3421,6 +5660,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3448,6 +5693,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -3471,6 +5725,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/topojson-client": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -3490,6 +5750,30 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
+    "node_modules/topojson-server/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@turf/turf": "^7.3.4",
     "d3": "^7.9.0",
     "dexie": "^4.3.0",
     "leaflet": "^1.9.4",

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -224,8 +224,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  position: sticky;
-  top: 0;
+  position: relative;
 }
 
 .map-container .leaflet-container {
@@ -292,4 +291,102 @@
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
+}
+
+/* Map Mode Toggle */
+.map-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--background);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+}
+
+.mode-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  background: transparent;
+  border: none;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mode-btn:hover {
+  color: var(--text);
+}
+
+.mode-btn.active {
+  background: var(--primary);
+  color: white;
+}
+
+.dot-matrix-select {
+  margin-left: 0.25rem;
+  padding: 0.35rem 0.5rem;
+  border: none;
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.dot-matrix-select:focus {
+  outline: none;
+}
+
+/* Map Legend */
+.map-legend {
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  max-width: 220px;
+  font-size: 0.75rem;
+}
+
+.map-legend .legend-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text);
+  font-size: 0.8rem;
+}
+
+.map-legend .legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+}
+
+.map-legend .legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.map-legend .legend-label {
+  flex: 1;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.map-legend .legend-value {
+  font-weight: 600;
+  color: var(--text);
 }

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { MapContainer, TileLayer, GeoJSON, CircleMarker, Popup } from 'react-leaflet'
 import { feature } from 'topojson-client'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Cell } from 'recharts'
-import { Droplets, Filter, AlertCircle, RefreshCw, MapPin, Map, ArrowDownCircle } from 'lucide-react'
+import { Droplets, Filter, AlertCircle, RefreshCw, MapPin, Map, ArrowDownCircle, Grid3X3, Circle } from 'lucide-react'
 import { useWaterFacilities } from './hooks'
 import { aggregateByGeography } from './api'
+import { generateDotMatrixForRegions } from './dotMatrix'
 import './App.css'
 
 function App() {
@@ -15,6 +16,8 @@ function App() {
   const [selectedDistrict, setSelectedDistrict] = useState('')
   const [showScrollHint, setShowScrollHint] = useState(true)
   const [colorMap, setColorMap] = useState({})
+  const [mapMode, setMapMode] = useState('markers') // 'markers' or 'dotMatrix'
+  const [dotMatrixIndicator, setDotMatrixIndicator] = useState('waterSource')
   const sidebarRef = useRef(null)
 
   // Handle sidebar scroll to show/hide scroll hint
@@ -147,6 +150,44 @@ function App() {
     return sortWithUnknownLast(data).slice(0, 10)
   }, [filteredData])
 
+  // Dot matrix indicator options
+  const dotMatrixIndicators = [
+    { key: 'waterSource', label: 'Water Source Type' },
+    { key: 'extractionType', label: 'Extraction Type' },
+    { key: 'owner', label: 'Ownership' },
+    { key: 'technologyType', label: 'Technology Type' },
+  ]
+
+  // Generate dot matrix data
+  const dotMatrixData = useMemo(() => {
+    if (mapMode !== 'dotMatrix' || !boundaries || !filteredData || filteredData.length === 0) {
+      return []
+    }
+    return generateDotMatrixForRegions(
+      boundaries,
+      filteredData,
+      dotMatrixIndicator,
+      (name) => getColor(name, '#9CA3AF'),
+      0.012
+    )
+  }, [mapMode, boundaries, filteredData, dotMatrixIndicator, colorMap])
+
+  // Get unique categories for legend
+  const dotMatrixLegend = useMemo(() => {
+    if (mapMode !== 'dotMatrix' || !filteredData || filteredData.length === 0) return []
+    const counts = {}
+    filteredData.forEach(f => {
+      const value = f[dotMatrixIndicator] || 'Unknown'
+      counts[value] = (counts[value] || 0) + 1
+    })
+    return sortWithUnknownLast(
+      Object.entries(counts).map(([name, value]) => ({
+        name,
+        value,
+        color: getColor(name, '#9CA3AF')
+      }))
+    )
+  }, [mapMode, filteredData, dotMatrixIndicator, colorMap])
 
   // Water points with coordinates for map markers
   const mapMarkers = useMemo(() => {
@@ -185,6 +226,17 @@ function App() {
       feature.properties.district === districts.find(d => d.id === parseInt(selectedDistrict))?.name
     const isCountySelected = selectedCounty &&
       feature.properties.county === counties.find(c => c.id === parseInt(selectedCounty))?.name
+
+    // In dot matrix mode, use transparent fill
+    if (mapMode === 'dotMatrix') {
+      return {
+        fillColor: 'transparent',
+        weight: isSelected ? 2 : 1,
+        opacity: 1,
+        color: isSelected ? '#1d4ed8' : '#64748b',
+        fillOpacity: 0,
+      }
+    }
 
     // Color by water point count if we have data
     let fillColor = '#cbd5e1'
@@ -290,6 +342,36 @@ function App() {
           <RefreshCw size={16} className={apiLoading ? 'spinning' : ''} />
         </button>
 
+        <div className="map-mode-toggle">
+          <button
+            className={`mode-btn ${mapMode === 'markers' ? 'active' : ''}`}
+            onClick={() => setMapMode('markers')}
+            title="Show water point markers"
+          >
+            <Circle size={14} />
+            <span>Markers</span>
+          </button>
+          <button
+            className={`mode-btn ${mapMode === 'dotMatrix' ? 'active' : ''}`}
+            onClick={() => setMapMode('dotMatrix')}
+            title="Show dot matrix visualization"
+          >
+            <Grid3X3 size={14} />
+            <span>Dot Matrix</span>
+          </button>
+          {mapMode === 'dotMatrix' && (
+            <select
+              value={dotMatrixIndicator}
+              onChange={(e) => setDotMatrixIndicator(e.target.value)}
+              className="dot-matrix-select"
+            >
+              {dotMatrixIndicators.map(ind => (
+                <option key={ind.key} value={ind.key}>{ind.label}</option>
+              ))}
+            </select>
+          )}
+        </div>
+
         <div className="stats-inline">
           <div className="stat-badge">
             <Droplets size={14} />
@@ -343,14 +425,14 @@ function App() {
                 data={boundaries}
                 style={getDistrictStyle}
                 onEachFeature={onEachDistrict}
-                key={`${selectedCounty}-${selectedDistrict}-${filteredData?.length || 0}`}
+                key={`${selectedCounty}-${selectedDistrict}-${filteredData?.length || 0}-${mapMode}`}
               />
             )}
-            {mapMarkers.map((facility, idx) => (
+            {mapMode === 'markers' && mapMarkers.map((facility, idx) => (
               <CircleMarker
                 key={facility.osid || idx}
                 center={[parseFloat(facility.latitude), parseFloat(facility.longitude)]}
-                radius={4}
+                radius={2}
                 fillColor="#2563eb"
                 color="#1d4ed8"
                 weight={1}
@@ -365,7 +447,36 @@ function App() {
                 </Popup>
               </CircleMarker>
             ))}
+            {mapMode === 'dotMatrix' && (
+              <React.Fragment key={`dots-${dotMatrixIndicator}`}>
+                {dotMatrixData.map((dot, idx) => (
+                  <CircleMarker
+                    key={idx}
+                    center={[dot.coordinates[1], dot.coordinates[0]]}
+                    radius={2}
+                    fillColor={dot.color}
+                    color={dot.color}
+                    weight={0}
+                    fillOpacity={1}
+                  />
+                ))}
+              </React.Fragment>
+            )}
           </MapContainer>
+          {mapMode === 'dotMatrix' && dotMatrixLegend.length > 0 && (
+            <div className="map-legend">
+              <div className="legend-title">
+                {dotMatrixIndicators.find(i => i.key === dotMatrixIndicator)?.label}
+              </div>
+              {dotMatrixLegend.slice(0, 8).map((item) => (
+                <div key={item.name} className="legend-item">
+                  <span className="legend-dot" style={{ backgroundColor: item.color }} />
+                  <span className="legend-label">{item.name}</span>
+                  <span className="legend-value">{item.value.toLocaleString()}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="sidebar" ref={sidebarRef} onScroll={handleSidebarScroll}>

--- a/dashboard/src/dotMatrix.js
+++ b/dashboard/src/dotMatrix.js
@@ -1,0 +1,149 @@
+import * as turf from '@turf/turf'
+
+/**
+ * Generate dot matrix points within a polygon
+ * @param {Object} feature - GeoJSON feature (polygon)
+ * @param {Array} categories - Array of { name, value, color } objects
+ * @param {number} cellSize - Size of hex grid cells in degrees (default 0.015)
+ * @returns {Array} Array of dot objects with coordinates, category, and color
+ */
+export function generateDotMatrix(feature, categories, cellSize = 0.015) {
+  try {
+    if (!feature || !categories || categories.length === 0) {
+      return []
+    }
+
+    const bbox = turf.bbox(feature)
+
+    // Use hex grid for honeycomb pattern (no gaps, radial look)
+    const hexGrid = turf.hexGrid(bbox, cellSize, { units: 'degrees' })
+
+    // Get centroids of hex cells that intersect with polygon, with random jitter
+    const jitterAmount = cellSize * 0.7
+    const pointsInPolygon = []
+
+    hexGrid.features.forEach((hex) => {
+      try {
+        const centroid = turf.centroid(hex)
+        // Add random jitter to position
+        const jitteredLng = centroid.geometry.coordinates[0] + (Math.random() - 0.5) * jitterAmount
+        const jitteredLat = centroid.geometry.coordinates[1] + (Math.random() - 0.5) * jitterAmount
+        const jitteredPoint = turf.point([jitteredLng, jitteredLat])
+
+        if (turf.booleanPointInPolygon(jitteredPoint, feature)) {
+          pointsInPolygon.push(jitteredPoint)
+        } else if (turf.booleanPointInPolygon(centroid, feature)) {
+          // Fallback to original centroid if jittered point is outside
+          pointsInPolygon.push(centroid)
+        }
+      } catch {
+        // Skip invalid geometries
+      }
+    })
+
+    if (pointsInPolygon.length === 0) {
+      return []
+    }
+
+    // Calculate proportions for each category
+    const total = categories.reduce((sum, c) => sum + (c.value || 0), 0)
+    if (total === 0) return []
+
+    const categoryProportions = categories.map((c) => ({
+      name: c.name,
+      proportion: (c.value || 0) / total,
+      color: c.color,
+    }))
+
+    // Shuffle points for random color distribution
+    const shuffledIndices = pointsInPolygon.map((_, i) => i).sort(() => Math.random() - 0.5)
+
+    const dots = []
+    shuffledIndices.forEach((originalIndex, newIndex) => {
+      const point = pointsInPolygon[originalIndex]
+      const ratio = newIndex / pointsInPolygon.length
+      let assignedCategory = categoryProportions[categoryProportions.length - 1]
+
+      let cumulative = 0
+      for (const category of categoryProportions) {
+        cumulative += category.proportion
+        if (ratio < cumulative) {
+          assignedCategory = category
+          break
+        }
+      }
+
+      dots.push({
+        coordinates: point.geometry.coordinates,
+        category: assignedCategory.name,
+        color: assignedCategory.color,
+      })
+    })
+
+    return dots
+  } catch (error) {
+    console.error('Error generating dot matrix:', error)
+    return []
+  }
+}
+
+/**
+ * Generate dot matrix for multiple regions based on facility data
+ * @param {Object} geoJsonData - GeoJSON FeatureCollection with district boundaries
+ * @param {Array} facilities - Array of facility objects
+ * @param {string} groupByField - Field to group facilities by (e.g., 'waterSource', 'owner')
+ * @param {Function} getColor - Function to get color for a category name
+ * @param {number} cellSize - Size of hex grid cells
+ * @returns {Array} Array of all dots across all regions
+ */
+export function generateDotMatrixForRegions(
+  geoJsonData,
+  facilities,
+  groupByField,
+  getColor,
+  cellSize = 0.015
+) {
+  if (!geoJsonData || !facilities || facilities.length === 0) {
+    return []
+  }
+
+  const allDots = []
+
+  geoJsonData.features.forEach((feature) => {
+    const districtName = feature.properties.district
+    const countyName = feature.properties.county
+
+    // Filter facilities for this district
+    const districtFacilities = facilities.filter(
+      (f) => f.districtName === districtName && f.countyName === countyName
+    )
+
+    if (districtFacilities.length === 0) return
+
+    // Group facilities by the specified field
+    const counts = {}
+    districtFacilities.forEach((f) => {
+      const value = f[groupByField] || 'Unknown'
+      counts[value] = (counts[value] || 0) + 1
+    })
+
+    // Convert to categories array with colors
+    const categories = Object.entries(counts).map(([name, value]) => ({
+      name,
+      value,
+      color: getColor(name),
+    }))
+
+    // Generate dots for this district
+    const dots = generateDotMatrix(feature, categories, cellSize)
+    dots.forEach((dot) => {
+      allDots.push({
+        ...dot,
+        district: districtName,
+        county: countyName,
+      })
+    })
+  })
+
+  return allDots
+}


### PR DESCRIPTION
## Summary
- Add alternative map visualization mode using dot matrix pattern within district boundaries
- Toggle between traditional markers and dot matrix modes via UI buttons
- Select indicator for dot matrix coloring (water source, extraction type, owner, technology)
- Color-coded dots based on category using the indicator color scheme
- Legend showing category distribution with counts

## Changes
- Added `@turf/turf` dependency for geospatial calculations
- New `dotMatrix.js` utility for generating hex grid dots within polygons
- Updated `App.jsx` with mode toggle, indicator selector, and dot rendering
- Added CSS styles for mode toggle buttons and map legend

## Test plan
- [ ] Switch between Markers and Dot Matrix modes
- [ ] Change indicator dropdown and verify dots update with different colors
- [ ] Verify legend updates with correct categories and counts
- [ ] Test with different county/district filters

🤖 Generated with [Claude Code](https://claude.ai/code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213314094574606